### PR TITLE
(rapier) reproduction for issue 666: friction not applied

### DIFF
--- a/examples3d/debug_boxes3.rs
+++ b/examples3d/debug_boxes3.rs
@@ -16,23 +16,31 @@ pub fn init_world(testbed: &mut Testbed) {
     let ground_size = 100.1;
     let ground_height = 0.1;
 
-    for _ in 0..6 {
-        let rigid_body = RigidBodyBuilder::fixed().translation(vector![0.0, -ground_height, 0.0]);
-        let handle = bodies.insert(rigid_body);
-        let collider = ColliderBuilder::cuboid(ground_size, ground_height, ground_size);
-        colliders.insert_with_parent(collider, handle, &mut bodies);
-    }
+    let ground_height = 0.1;
+    colliders.insert_with_parent(
+        ColliderBuilder::cuboid(100.1, ground_height, 100.1).friction(0.5),
+        bodies.insert(RigidBodyBuilder::fixed().translation(vector![0.0, -ground_height, 0.0])),
+        &mut bodies,
+    );
 
-    // Build the dynamic box rigid body.
-    for _ in 0..2 {
-        let rigid_body = RigidBodyBuilder::dynamic()
-            .translation(vector![1.1, 0.0, 0.0])
-            // .rotation(vector![0.8, 0.2, 0.1])
-            .can_sleep(false);
-        let handle = bodies.insert(rigid_body);
-        let collider = ColliderBuilder::cuboid(2.0, 0.1, 1.0);
-        colliders.insert_with_parent(collider, handle, &mut bodies);
-    }
+    let (collider_mass, rigidbody_additional_mass) = (0.0, 0.5);
+
+    // NOTE: #666: uncomment this to test "expected" behaviour.
+    //let (collider_mass, rigidbody_additional_mass) = (0.5, 0.0);
+
+    colliders.insert_with_parent(
+        ColliderBuilder::cuboid(0.2, 5., 1.5)
+            .friction(0.5)
+            .mass(collider_mass),
+        bodies.insert(
+            RigidBodyBuilder::dynamic()
+                .additional_mass(rigidbody_additional_mass)
+                .translation(vector![-10., 6.0, 0.0])
+                .linvel(vector![20., 0., 0.])
+                .can_sleep(false),
+        ),
+        &mut bodies,
+    );
 
     /*
      * Set up the testbed.


### PR DESCRIPTION
- context: https://github.com/dimforge/rapier/issues/666

With collider mass at 0.5 and rigidbody additional mass at 0.0, here is the current behaviour, which is expected:

https://github.com/user-attachments/assets/0880b1e7-af6b-4712-8834-7657fa228422

With collider mass at 0.0 and rigidbody additional mass at 0.5, here is the current behaviour, which is **unexpected**:

https://github.com/user-attachments/assets/e062d7cb-83d1-4a11-a842-cdb89c832887


