### PR TITLE
Parry update simpler traverse

### DIFF
--- a/.github/workflows/rapier-ci-build.yml
+++ b/.github/workflows/rapier-ci-build.yml
@@ -75,9 +75,9 @@ jobs:
       - uses: actions/checkout@v4
       - run: rustup target add wasm32-unknown-unknown
       - name: build rapier2d
-        run: cd crates/rapier2d && cargo build --verbose --features wasm-bindgen --target wasm32-unknown-unknown;
+        run: cd crates/rapier2d && cargo build --verbose --target wasm32-unknown-unknown;
       - name: build rapier3d
-        run: cd crates/rapier3d && cargo build --verbose --features wasm-bindgen --target wasm32-unknown-unknown;
+        run: cd crates/rapier3d && cargo build --verbose --target wasm32-unknown-unknown;
   build-wasm-emscripten:
     runs-on: ubuntu-latest
     env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - `InteractionGroups` default value for `memberships` is now `GROUP_1` (#706)
 - `ImpulseJointSet::get_mut` has a new parameter `wake_up: bool`, to wake up connected bodies.
+- Removed unmaintained `instant` in favor of `web-time`. This effectively removes the `wasm-bindgen` transitive dependency as it's no longer needed.
 
 ## v0.22.0 (20 July 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `InteractionGroups` default value for `memberships` is now `GROUP_1` (#706)
 - `ImpulseJointSet::get_mut` has a new parameter `wake_up: bool`, to wake up connected bodies.
 - Removed unmaintained `instant` in favor of `web-time`. This effectively removes the `wasm-bindgen` transitive dependency as it's no longer needed.
+- Significantly improve performances of `QueryPipeline::intersection_with_shape`.
 
 ## v0.22.0 (20 July 2024)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ If you would like to fix it yourself, here is the procedure:
 
 ## Contributing to the JavaScript/TypeScript bindings
 The source code of the official JavaScript/TypeScript bindings for Rapier are available
-on our `rapier.js` repository [on GitHub](https://github.com/dimforge/rapier.rs).
+on our `rapier.js` repository [on GitHub](https://github.com/dimforge/rapier.js).
 
 You will have to make sure that you have [wasm-pack](https://github.com/rustwasm/wasm-pack) installed because
 it is responsible for generating the low-level bindings. In order to modify the bindings and test your

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,14 +39,10 @@ resolver = "2"
 #parry3d-f64 = { git = "https://github.com/dimforge/parry", branch = "master" }
 
 
-# parry2d = { git = "https://github.com/Vrixyz/parry", branch = "273-shape-shape-best" }
-# parry3d = { git = "https://github.com/Vrixyz/parry", branch = "273-shape-shape-best" }
-# parry2d-f64 = { git = "https://github.com/Vrixyz/parry", branch = "273-shape-shape-best" }
-# parry3d-f64 = { git = "https://github.com/Vrixyz/parry", branch = "273-shape-shape-best" }
-parry2d = { path = "../parry/crates/parry2d" }
-parry3d = { path = "../parry/crates/parry3d" }
-parry2d-f64 = { path = "../parry/crates/parry2d-f64" }
-parry3d-f64 = { path = "../parry/crates/parry3d-f64" }
+parry2d = { git = "https://github.com/Vrixyz/parry", branch = "273-shape-shape-partId" }
+parry3d = { git = "https://github.com/Vrixyz/parry", branch = "273-shape-shape-partId" }
+parry2d-f64 = { git = "https://github.com/Vrixyz/parry", branch = "273-shape-shape-partId" }
+parry3d-f64 = { git = "https://github.com/Vrixyz/parry", branch = "273-shape-shape-partId" }
 
 # # For feature unstable-puffin-pr-235
 # # See https://github.com/dimforge/rapier/issues/760.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,10 +39,14 @@ resolver = "2"
 #parry3d-f64 = { git = "https://github.com/dimforge/parry", branch = "master" }
 
 
-parry2d = { git = "https://github.com/Vrixyz/parry", branch = "273-shape-shape-best" }
-parry3d = { git = "https://github.com/Vrixyz/parry", branch = "273-shape-shape-best" }
-parry2d-f64 = { git = "https://github.com/Vrixyz/parry", branch = "273-shape-shape-best" }
-parry3d-f64 = { git = "https://github.com/Vrixyz/parry", branch = "273-shape-shape-best" }
+# parry2d = { git = "https://github.com/Vrixyz/parry", branch = "273-shape-shape-best" }
+# parry3d = { git = "https://github.com/Vrixyz/parry", branch = "273-shape-shape-best" }
+# parry2d-f64 = { git = "https://github.com/Vrixyz/parry", branch = "273-shape-shape-best" }
+# parry3d-f64 = { git = "https://github.com/Vrixyz/parry", branch = "273-shape-shape-best" }
+parry2d = { path = "../parry/crates/parry2d" }
+parry3d = { path = "../parry/crates/parry3d" }
+parry2d-f64 = { path = "../parry/crates/parry2d-f64" }
+parry3d-f64 = { path = "../parry/crates/parry3d-f64" }
 
 # # For feature unstable-puffin-pr-235
 # # See https://github.com/dimforge/rapier/issues/760.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,10 +39,10 @@ resolver = "2"
 #parry3d-f64 = { git = "https://github.com/dimforge/parry", branch = "master" }
 
 
-parry2d = { git = "https://github.com/Vrixyz/parry", branch = "273-shape-shape-partId" }
-parry3d = { git = "https://github.com/Vrixyz/parry", branch = "273-shape-shape-partId" }
-parry2d-f64 = { git = "https://github.com/Vrixyz/parry", branch = "273-shape-shape-partId" }
-parry3d-f64 = { git = "https://github.com/Vrixyz/parry", branch = "273-shape-shape-partId" }
+parry2d = { git = "https://github.com/dimforge/parry" }
+parry3d = { git = "https://github.com/dimforge/parry" }
+parry2d-f64 = { git = "https://github.com/dimforge/parry" }
+parry3d-f64 = { git = "https://github.com/dimforge/parry" }
 
 # # For feature unstable-puffin-pr-235
 # # See https://github.com/dimforge/rapier/issues/760.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,12 @@ resolver = "2"
 #parry2d-f64 = { git = "https://github.com/dimforge/parry", branch = "master" }
 #parry3d-f64 = { git = "https://github.com/dimforge/parry", branch = "master" }
 
+
+parry2d = { git = "https://github.com/Vrixyz/parry", branch = "273-shape-shape-best" }
+parry3d = { git = "https://github.com/Vrixyz/parry", branch = "273-shape-shape-best" }
+parry2d-f64 = { git = "https://github.com/Vrixyz/parry", branch = "273-shape-shape-best" }
+parry3d-f64 = { git = "https://github.com/Vrixyz/parry", branch = "273-shape-shape-best" }
+
 # # For feature unstable-puffin-pr-235
 # # See https://github.com/dimforge/rapier/issues/760.
 # puffin_egui = { version = "0.29", optional = true, git = "https://github.com/Vrixyz/puffin.git", branch = "expose_ui_options" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,12 +38,6 @@ resolver = "2"
 #parry2d-f64 = { git = "https://github.com/dimforge/parry", branch = "master" }
 #parry3d-f64 = { git = "https://github.com/dimforge/parry", branch = "master" }
 
-
-parry2d = { git = "https://github.com/dimforge/parry" }
-parry3d = { git = "https://github.com/dimforge/parry" }
-parry2d-f64 = { git = "https://github.com/dimforge/parry" }
-parry3d-f64 = { git = "https://github.com/dimforge/parry" }
-
 # # For feature unstable-puffin-pr-235
 # # See https://github.com/dimforge/rapier/issues/760.
 # puffin_egui = { version = "0.29", optional = true, git = "https://github.com/Vrixyz/puffin.git", branch = "expose_ui_options" }

--- a/benchmarks3d/trimesh3.rs
+++ b/benchmarks3d/trimesh3.rs
@@ -38,7 +38,7 @@ pub fn init_world(testbed: &mut Testbed) {
 
     let rigid_body = RigidBodyBuilder::fixed();
     let handle = bodies.insert(rigid_body);
-    let collider = ColliderBuilder::trimesh(vertices, indices);
+    let collider = ColliderBuilder::trimesh(vertices, indices).unwrap();
     colliders.insert_with_parent(collider, handle, &mut bodies);
 
     /*

--- a/crates/rapier2d-f64/Cargo.toml
+++ b/crates/rapier2d-f64/Cargo.toml
@@ -68,7 +68,7 @@ vec_map = { version = "0.8", optional = true }
 web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.33"
-parry2d-f64 = "0.17.0"
+parry2d-f64 = "0.18.0"
 simba = "0.9"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier2d-f64/Cargo.toml
+++ b/crates/rapier2d-f64/Cargo.toml
@@ -36,7 +36,6 @@ simd-nightly = ["simba/portable_simd", "simd-is-enabled"]
 # Do not enable this feature directly. It is automatically
 # enabled with the "simd-stable" or "simd-nightly" feature.
 simd-is-enabled = ["dep:vec_map"]
-wasm-bindgen = ["instant/wasm-bindgen"]
 serde-serialize = [
     "nalgebra/serde-serialize",
     "parry2d-f64/serde-serialize",
@@ -46,7 +45,7 @@ serde-serialize = [
 ]
 enhanced-determinism = ["simba/libm_force", "parry2d-f64/enhanced-determinism"]
 debug-render = []
-profiler = ["dep:instant"] # Enables the internal profiler.
+profiler = ["dep:web-time"] # Enables the internal profiler.
 
 # Feature used for debugging only.
 debug-disable-legitimate-fe-exceptions = []
@@ -66,7 +65,7 @@ required-features = ["dim2", "f64"]
 
 [dependencies]
 vec_map = { version = "0.8", optional = true }
-instant = { version = "0.1", features = ["now"], optional = true }
+web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.33"
 parry2d-f64 = "0.17.0"

--- a/crates/rapier2d/Cargo.toml
+++ b/crates/rapier2d/Cargo.toml
@@ -36,7 +36,6 @@ simd-nightly = ["simba/portable_simd", "simd-is-enabled"]
 # Do not enable this feature directly. It is automatically
 # enabled with the "simd-stable" or "simd-nightly" feature.
 simd-is-enabled = ["dep:vec_map"]
-wasm-bindgen = ["instant/wasm-bindgen"]
 serde-serialize = [
     "nalgebra/serde-serialize",
     "parry2d/serde-serialize",
@@ -46,7 +45,7 @@ serde-serialize = [
 ]
 enhanced-determinism = ["simba/libm_force", "parry2d/enhanced-determinism"]
 debug-render = []
-profiler = ["dep:instant"] # Enables the internal profiler.
+profiler = ["dep:web-time"] # Enables the internal profiler.
 
 # Feature used for debugging only.
 debug-disable-legitimate-fe-exceptions = []
@@ -66,7 +65,7 @@ required-features = ["dim2", "f32"]
 
 [dependencies]
 vec_map = { version = "0.8", optional = true }
-instant = { version = "0.1", features = ["now"], optional = true }
+web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.33"
 parry2d = "0.17.0"

--- a/crates/rapier2d/Cargo.toml
+++ b/crates/rapier2d/Cargo.toml
@@ -68,7 +68,7 @@ vec_map = { version = "0.8", optional = true }
 web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.33"
-parry2d = "0.17.0"
+parry2d = "0.18.0"
 simba = "0.9"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier3d-f64/Cargo.toml
+++ b/crates/rapier3d-f64/Cargo.toml
@@ -40,7 +40,6 @@ simd-nightly = [
 # Do not enable this feature directly. It is automatically
 # enabled with the "simd-stable" or "simd-nightly" feature.
 simd-is-enabled = ["dep:vec_map"]
-wasm-bindgen = ["instant/wasm-bindgen"]
 serde-serialize = [
     "nalgebra/serde-serialize",
     "parry3d-f64/serde-serialize",
@@ -49,7 +48,7 @@ serde-serialize = [
 ]
 enhanced-determinism = ["simba/libm_force", "parry3d-f64/enhanced-determinism"]
 debug-render = []
-profiler = ["dep:instant"] # Enables the internal profiler.
+profiler = ["dep:web-time"] # Enables the internal profiler.
 
 # Feature used for debugging only.
 debug-disable-legitimate-fe-exceptions = []
@@ -69,7 +68,7 @@ required-features = ["dim3", "f64"]
 
 [dependencies]
 vec_map = { version = "0.8", optional = true }
-instant = { version = "0.1", features = ["now"], optional = true }
+web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.33"
 parry3d-f64 = "0.17.0"

--- a/crates/rapier3d-f64/Cargo.toml
+++ b/crates/rapier3d-f64/Cargo.toml
@@ -71,7 +71,7 @@ vec_map = { version = "0.8", optional = true }
 web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.33"
-parry3d-f64 = "0.17.0"
+parry3d-f64 = "0.18.0"
 simba = "0.9"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier3d-meshloader/Cargo.toml
+++ b/crates/rapier3d-meshloader/Cargo.toml
@@ -27,6 +27,6 @@ wavefront = ["mesh-loader/obj"]
 [dependencies]
 thiserror = "1.0.61"
 profiling = "1.0"
-mesh-loader = { version = "0.1.12", optional = true }
+mesh-loader = "0.1.12"
 
 rapier3d = { version = "0.22", path = "../rapier3d" }

--- a/crates/rapier3d-urdf/Cargo.toml
+++ b/crates/rapier3d-urdf/Cargo.toml
@@ -19,9 +19,11 @@ license = "Apache-2.0"
 edition = "2021"
 
 [features]
-stl = ["dep:rapier3d-meshloader", "rapier3d-meshloader/stl"]
-collada = ["dep:rapier3d-meshloader", "rapier3d-meshloader/collada"]
-wavefront = ["dep:rapier3d-meshloader", "rapier3d-meshloader/wavefront"]
+stl = ["dep:rapier3d-meshloader", "rapier3d-meshloader/stl", "__meshloader_is_enabled"]
+collada = ["dep:rapier3d-meshloader", "rapier3d-meshloader/collada", "__meshloader_is_enabled"]
+wavefront = ["dep:rapier3d-meshloader", "rapier3d-meshloader/wavefront", "__meshloader_is_enabled"]
+## Private feature for detecting when meshloader is enabled by any of the file type features above.
+__meshloader_is_enabled = []
 
 [dependencies]
 log = "0.4"

--- a/crates/rapier3d-urdf/src/lib.rs
+++ b/crates/rapier3d-urdf/src/lib.rs
@@ -37,7 +37,6 @@ use rapier3d::{
     geometry::{Collider, ColliderBuilder, ColliderHandle, ColliderSet, SharedShape, TriMeshFlags},
     math::{Isometry, Point, Real, Vector},
     na,
-    prelude::MeshConverter,
 };
 use std::collections::HashMap;
 use std::path::Path;
@@ -462,7 +461,7 @@ fn urdf_to_rigid_body(options: &UrdfLoaderOptions, inertial: &Inertial) -> Rigid
 
 fn urdf_to_colliders(
     options: &UrdfLoaderOptions,
-    mesh_dir: &Path,
+    _mesh_dir: &Path, // Unused if none of the meshloader features is enabled.
     geometry: &Geometry,
     origin: &Pose,
 ) -> Vec<Collider> {
@@ -496,14 +495,20 @@ fn urdf_to_colliders(
         Geometry::Sphere { radius } => {
             colliders.push(SharedShape::ball(*radius as Real));
         }
+        #[cfg(not(feature = "__meshloader_is_enabled"))]
+        Geometry::Mesh {..} => {
+            log::error!("Mesh loading is disabled by default. Enable one of the format features (`stl`, `collada`, `wavefront`) of `rapier3d-urdf` for mesh support.");
+        }
+        #[cfg(feature = "__meshloader_is_enabled")]
         Geometry::Mesh { filename, scale } => {
-            let full_path = mesh_dir.join(filename);
+            let full_path = _mesh_dir.join(filename);
             let scale = scale
                 .map(|s| Vector::new(s[0] as Real, s[1] as Real, s[2] as Real))
                 .unwrap_or_else(|| Vector::<Real>::repeat(1.0));
+
             let Ok(loaded_mesh) = rapier3d_meshloader::load_from_path(
                 full_path,
-                &MeshConverter::TriMeshWithFlags(options.trimesh_flags),
+                &rapier3d::prelude::MeshConverter::TriMeshWithFlags(options.trimesh_flags),
                 scale,
             ) else {
                 return Vec::new();

--- a/crates/rapier3d-urdf/src/lib.rs
+++ b/crates/rapier3d-urdf/src/lib.rs
@@ -496,7 +496,7 @@ fn urdf_to_colliders(
             colliders.push(SharedShape::ball(*radius as Real));
         }
         #[cfg(not(feature = "__meshloader_is_enabled"))]
-        Geometry::Mesh {..} => {
+        Geometry::Mesh { .. } => {
             log::error!("Mesh loading is disabled by default. Enable one of the format features (`stl`, `collada`, `wavefront`) of `rapier3d-urdf` for mesh support.");
         }
         #[cfg(feature = "__meshloader_is_enabled")]

--- a/crates/rapier3d/Cargo.toml
+++ b/crates/rapier3d/Cargo.toml
@@ -40,7 +40,6 @@ simd-nightly = [
 # Do not enable this feature directly. It is automatically
 # enabled with the "simd-stable" or "simd-nightly" feature.
 simd-is-enabled = ["dep:vec_map"]
-wasm-bindgen = ["instant/wasm-bindgen"]
 serde-serialize = [
     "nalgebra/serde-serialize",
     "parry3d/serde-serialize",
@@ -49,7 +48,7 @@ serde-serialize = [
 ]
 enhanced-determinism = ["simba/libm_force", "parry3d/enhanced-determinism"]
 debug-render = []
-profiler = ["dep:instant"] # Enables the internal profiler.
+profiler = ["dep:web-time"] # Enables the internal profiler.
 
 # Feature used for debugging only.
 debug-disable-legitimate-fe-exceptions = []
@@ -69,7 +68,7 @@ required-features = ["dim3", "f32"]
 
 [dependencies]
 vec_map = { version = "0.8", optional = true }
-instant = { version = "0.1", features = ["now"], optional = true }
+web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.33"
 parry3d = "0.17.0"

--- a/crates/rapier3d/Cargo.toml
+++ b/crates/rapier3d/Cargo.toml
@@ -71,7 +71,7 @@ vec_map = { version = "0.8", optional = true }
 web-time = { version = "1.1", optional = true }
 num-traits = "0.2"
 nalgebra = "0.33"
-parry3d = "0.17.0"
+parry3d = "0.18.0"
 simba = "0.9"
 approx = "0.5"
 rayon = { version = "1", optional = true }

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -34,7 +34,7 @@ default = ["dim2"]
 dim2 = []
 parallel = ["rapier/parallel", "num_cpus"]
 other-backends = ["wrapped2d"]
-profiler_ui = [] #["dep:puffin_egui", "profiling/profile-with-puffin"]
+profiler_ui = ["dep:puffin_egui", "profiling/profile-with-puffin"]
 # See https://github.com/dimforge/rapier/issues/760.
 unstable-puffin-pr-235 = []
 

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -41,6 +41,9 @@ unstable-puffin-pr-235 = []
 [package.metadata.docs.rs]
 features = ["parallel", "profiling"]
 
+[lints.clippy]
+needless_lifetimes = "allow"
+
 [dependencies]
 nalgebra = { version = "0.33", features = ["rand", "glam027"] }
 rand = "0.8"

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -48,7 +48,7 @@ needless_lifetimes = "allow"
 nalgebra = { version = "0.33", features = ["rand", "glam027"] }
 rand = "0.8"
 rand_pcg = "0.3"
-instant = { version = "0.1", features = ["web-sys", "now"] }
+web-time = { version = "1.1" }
 bitflags = "2"
 num_cpus = { version = "1", optional = true }
 wrapped2d = { version = "0.4", optional = true }

--- a/crates/rapier_testbed2d-f64/Cargo.toml
+++ b/crates/rapier_testbed2d-f64/Cargo.toml
@@ -34,12 +34,12 @@ default = ["dim2"]
 dim2 = []
 parallel = ["rapier/parallel", "num_cpus"]
 other-backends = ["wrapped2d"]
-profiling = ["dep:puffin_egui", "profiling/profile-with-puffin"]
+profiler_ui = [] #["dep:puffin_egui", "profiling/profile-with-puffin"]
 # See https://github.com/dimforge/rapier/issues/760.
 unstable-puffin-pr-235 = []
 
 [package.metadata.docs.rs]
-features = ["parallel", "profiling"]
+features = ["parallel", "profiler_ui"]
 
 [lints.clippy]
 needless_lifetimes = "allow"

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -34,7 +34,7 @@ default = ["dim2"]
 dim2 = []
 parallel = ["rapier/parallel", "num_cpus"]
 other-backends = ["wrapped2d"]
-profiler_ui = [] #["dep:puffin_egui", "profiling/profile-with-puffin"]
+profiler_ui = ["dep:puffin_egui", "profiling/profile-with-puffin"]
 # See https://github.com/dimforge/rapier/issues/760.
 unstable-puffin-pr-235 = []
 
@@ -62,7 +62,7 @@ bevy_core_pipeline = "0.14"
 bevy_pbr = "0.14"
 bevy_sprite = "0.14"
 profiling = "1.0"
-#puffin_egui = { version = "0.29", optional = true }
+puffin_egui = { version = "0.29", optional = true }
 
 # Dependencies for native only.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -34,12 +34,12 @@ default = ["dim2"]
 dim2 = []
 parallel = ["rapier/parallel", "num_cpus"]
 other-backends = ["wrapped2d"]
-profiling = ["dep:puffin_egui", "profiling/profile-with-puffin"]
+profiler_ui = [] #["dep:puffin_egui", "profiling/profile-with-puffin"]
 # See https://github.com/dimforge/rapier/issues/760.
 unstable-puffin-pr-235 = []
 
 [package.metadata.docs.rs]
-features = ["parallel", "other-backends", "profiling"]
+features = ["parallel", "other-backends", "profiler_ui"]
 
 [lints.clippy]
 needless_lifetimes = "allow"
@@ -62,7 +62,7 @@ bevy_core_pipeline = "0.14"
 bevy_pbr = "0.14"
 bevy_sprite = "0.14"
 profiling = "1.0"
-puffin_egui = { version = "0.29", optional = true }
+#puffin_egui = { version = "0.29", optional = true }
 
 # Dependencies for native only.
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -41,6 +41,9 @@ unstable-puffin-pr-235 = []
 [package.metadata.docs.rs]
 features = ["parallel", "other-backends", "profiling"]
 
+[lints.clippy]
+needless_lifetimes = "allow"
+
 [dependencies]
 nalgebra = { version = "0.33", features = ["rand", "glam027"] }
 rand = "0.8"

--- a/crates/rapier_testbed2d/Cargo.toml
+++ b/crates/rapier_testbed2d/Cargo.toml
@@ -48,7 +48,7 @@ needless_lifetimes = "allow"
 nalgebra = { version = "0.33", features = ["rand", "glam027"] }
 rand = "0.8"
 rand_pcg = "0.3"
-instant = { version = "0.1", features = ["web-sys", "now"] }
+web-time = { version = "1.1" }
 bitflags = "2"
 num_cpus = { version = "1", optional = true }
 wrapped2d = { version = "0.4", optional = true }

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -36,12 +36,12 @@ rust.unexpected_cfgs = { level = "warn", check-cfg = [
 default = ["dim3"]
 dim3 = []
 parallel = ["rapier/parallel", "num_cpus"]
-profiling = ["dep:puffin_egui", "profiling/profile-with-puffin"]
+profiler_ui = [] #["dep:puffin_egui", "profiling/profile-with-puffin"]
 # See https://github.com/dimforge/rapier/issues/760.
 unstable-puffin-pr-235 = []
 
 [package.metadata.docs.rs]
-features = ["parallel", "profiling"]
+features = ["parallel", "profiler_ui"]
 
 [lints.clippy]
 needless_lifetimes = "allow"

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -43,6 +43,9 @@ unstable-puffin-pr-235 = []
 [package.metadata.docs.rs]
 features = ["parallel", "profiling"]
 
+[lints.clippy]
+needless_lifetimes = "allow"
+
 [dependencies]
 nalgebra = { version = "0.33", features = ["rand", "glam027"] }
 rand = "0.8"

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -36,7 +36,7 @@ rust.unexpected_cfgs = { level = "warn", check-cfg = [
 default = ["dim3"]
 dim3 = []
 parallel = ["rapier/parallel", "num_cpus"]
-profiler_ui = [] #["dep:puffin_egui", "profiling/profile-with-puffin"]
+profiler_ui = ["dep:puffin_egui", "profiling/profile-with-puffin"]
 # See https://github.com/dimforge/rapier/issues/760.
 unstable-puffin-pr-235 = []
 

--- a/crates/rapier_testbed3d-f64/Cargo.toml
+++ b/crates/rapier_testbed3d-f64/Cargo.toml
@@ -50,7 +50,7 @@ needless_lifetimes = "allow"
 nalgebra = { version = "0.33", features = ["rand", "glam027"] }
 rand = "0.8"
 rand_pcg = "0.3"
-instant = { version = "0.1", features = ["web-sys", "now"] }
+web-time = { version = "1.1" }
 bitflags = "2"
 num_cpus = { version = "1", optional = true }
 crossbeam = "0.8"

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -34,7 +34,7 @@ default = ["dim3"]
 dim3 = []
 parallel = ["rapier/parallel", "num_cpus"]
 other-backends = ["physx", "physx-sys", "glam"]
-profiler_ui = [] #["dep:puffin_egui", "profiling/profile-with-puffin"]
+profiler_ui = ["dep:puffin_egui", "profiling/profile-with-puffin"]
 # See https://github.com/dimforge/rapier/issues/760.
 unstable-puffin-pr-235 = []
 

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -41,6 +41,9 @@ unstable-puffin-pr-235 = []
 [package.metadata.docs.rs]
 features = ["parallel", "other-backends", "profiling"]
 
+[lints.clippy]
+needless_lifetimes = "allow"
+
 [dependencies]
 nalgebra = { version = "0.33", features = ["rand", "glam027"] }
 rand = "0.8"

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -34,12 +34,12 @@ default = ["dim3"]
 dim3 = []
 parallel = ["rapier/parallel", "num_cpus"]
 other-backends = ["physx", "physx-sys", "glam"]
-profiling = ["dep:puffin_egui", "profiling/profile-with-puffin"]
+profiler_ui = [] #["dep:puffin_egui", "profiling/profile-with-puffin"]
 # See https://github.com/dimforge/rapier/issues/760.
 unstable-puffin-pr-235 = []
 
 [package.metadata.docs.rs]
-features = ["parallel", "other-backends", "profiling"]
+features = ["parallel", "other-backends", "profiler_ui"]
 
 [lints.clippy]
 needless_lifetimes = "allow"

--- a/crates/rapier_testbed3d/Cargo.toml
+++ b/crates/rapier_testbed3d/Cargo.toml
@@ -48,7 +48,7 @@ needless_lifetimes = "allow"
 nalgebra = { version = "0.33", features = ["rand", "glam027"] }
 rand = "0.8"
 rand_pcg = "0.3"
-instant = { version = "0.1", features = ["web-sys", "now"] }
+web-time = { version = "1.1" }
 bitflags = "2"
 glam = { version = "0.27", optional = true } # For Physx
 num_cpus = { version = "1", optional = true }

--- a/examples2d/Cargo.toml
+++ b/examples2d/Cargo.toml
@@ -20,7 +20,7 @@ usvg = "0.14"
 
 [dependencies.rapier_testbed2d]
 path = "../crates/rapier_testbed2d"
-features = ["profiling"]
+#features = ["profiler_ui"]
 
 [dependencies.rapier2d]
 path = "../crates/rapier2d"

--- a/examples2d/Cargo.toml
+++ b/examples2d/Cargo.toml
@@ -20,7 +20,7 @@ usvg = "0.14"
 
 [dependencies.rapier_testbed2d]
 path = "../crates/rapier_testbed2d"
-#features = ["profiler_ui"]
+features = ["profiler_ui"]
 
 [dependencies.rapier2d]
 path = "../crates/rapier2d"

--- a/examples2d/all_examples2.rs
+++ b/examples2d/all_examples2.rs
@@ -16,6 +16,7 @@ mod convex_polygons2;
 mod damping2;
 mod debug_box_ball2;
 mod debug_compression2;
+mod debug_intersection2;
 mod debug_total_overlap2;
 mod debug_vertical_column2;
 mod drum2;
@@ -99,6 +100,7 @@ pub fn main() {
         ("Joint motor position", joint_motor_position2::init_world),
         ("(Debug) box ball", debug_box_ball2::init_world),
         ("(Debug) compression", debug_compression2::init_world),
+        ("(Debug) intersection", debug_intersection2::init_world),
         ("(Debug) total overlap", debug_total_overlap2::init_world),
         (
             "(Debug) vertical column",

--- a/examples2d/debug_intersection2.rs
+++ b/examples2d/debug_intersection2.rs
@@ -1,0 +1,66 @@
+use rapier2d::prelude::*;
+use rapier_testbed2d::Testbed;
+
+pub fn init_world(testbed: &mut Testbed) {
+    /*
+     * World
+     */
+    let mut bodies = RigidBodySet::new();
+    let mut colliders = ColliderSet::new();
+    let impulse_joints = ImpulseJointSet::new();
+    let multibody_joints = MultibodyJointSet::new();
+
+    let rad = 1.0;
+    let collider = ColliderBuilder::ball(rad);
+
+    let count = 100;
+    for x in 0..count {
+        for y in 0..count {
+            let rigid_body = RigidBodyBuilder::fixed().translation(vector![
+                (x as f32 - count as f32 / 2.0) * rad * 3.0,
+                (y as f32 - count as f32 / 2.0) * rad * 3.0
+            ]);
+            let handle = bodies.insert(rigid_body);
+            colliders.insert_with_parent(collider.clone(), handle, &mut bodies);
+            testbed.set_initial_body_color(
+                handle,
+                [
+                    x as f32 / count as f32,
+                    (count - y) as f32 / count as f32,
+                    0.5,
+                ],
+            );
+        }
+    }
+
+    /*
+     * Set up the testbed.
+     */
+    testbed.set_world(bodies, colliders, impulse_joints, multibody_joints);
+    testbed.look_at(point![0.0, 0.0], 50.0);
+
+    testbed.add_callback(move |graphics, physics, _, run| {
+        let slow_time = run.timestep_id as f32 / 3.0;
+        let intersection = physics.query_pipeline.intersection_with_shape(
+            &physics.bodies,
+            &physics.colliders,
+            &Isometry::translation(slow_time.cos() * 10.0, slow_time.sin() * 10.0),
+            &Ball::new(rad / 2.0),
+            QueryFilter::default(),
+        );
+
+        if let Some(graphics) = graphics {
+            for (handle, _) in physics.bodies.iter() {
+                graphics.set_body_color(handle, [0.5, 0.5, 0.5]);
+            }
+            if let Some(intersection) = intersection {
+                let collider = physics.colliders.get(intersection).unwrap();
+                let body_handle = collider.parent().unwrap();
+
+                graphics.set_body_color(body_handle, [1.0, 0.0, 0.0]);
+            }
+        }
+
+        //println!("intersection: {:?}", intersection);
+    });
+}

--- a/examples2d/debug_intersection2.rs
+++ b/examples2d/debug_intersection2.rs
@@ -60,7 +60,5 @@ pub fn init_world(testbed: &mut Testbed) {
                 graphics.set_body_color(body_handle, [1.0, 0.0, 0.0]);
             }
         }
-
-        //println!("intersection: {:?}", intersection);
     });
 }

--- a/examples2d/trimesh2.rs
+++ b/examples2d/trimesh2.rs
@@ -85,6 +85,7 @@ pub fn init_world(testbed: &mut Testbed) {
 
                 for k in 0..5 {
                     let collider = ColliderBuilder::trimesh(vertices.clone(), indices.clone())
+                        .unwrap()
                         .contact_skin(0.2);
                     let rigid_body = RigidBodyBuilder::dynamic()
                         .translation(vector![ith as f32 * 8.0 - 20.0, 20.0 + k as f32 * 11.0])

--- a/examples2d/trimesh2.rs
+++ b/examples2d/trimesh2.rs
@@ -143,7 +143,7 @@ pub struct PathConvIter<'a> {
     deferred: Option<PathEvent>,
 }
 
-impl<'l> Iterator for PathConvIter<'l> {
+impl Iterator for PathConvIter<'_> {
     type Item = PathEvent;
     fn next(&mut self) -> Option<PathEvent> {
         if self.deferred.is_some() {

--- a/examples3d/Cargo.toml
+++ b/examples3d/Cargo.toml
@@ -23,7 +23,7 @@ bincode = "1"
 
 [dependencies.rapier_testbed3d]
 path = "../crates/rapier_testbed3d"
-features = ["profiling"]
+features = ["profiler_ui"]
 
 [dependencies.rapier3d]
 path = "../crates/rapier3d"

--- a/examples3d/debug_trimesh3.rs
+++ b/examples3d/debug_trimesh3.rs
@@ -48,7 +48,7 @@ pub fn init_world(testbed: &mut Testbed) {
 
     let rigid_body = RigidBodyBuilder::fixed().translation(vector![0.0, 0.0, 0.0]);
     let handle = bodies.insert(rigid_body);
-    let collider = ColliderBuilder::trimesh(vtx, idx);
+    let collider = ColliderBuilder::trimesh(vtx, idx).expect("Could not create trimesh collider.");
     colliders.insert_with_parent(collider, handle, &mut bodies);
     testbed.set_initial_body_color(handle, [0.3, 0.3, 0.3]);
 

--- a/examples3d/dynamic_trimesh3.rs
+++ b/examples3d/dynamic_trimesh3.rs
@@ -93,6 +93,7 @@ pub fn do_init_world(testbed: &mut Testbed, use_convex_decomposition: bool) {
             } else {
                 // SharedShape::trimesh(vertices, indices)
                 SharedShape::trimesh_with_flags(vertices, indices, TriMeshFlags::FIX_INTERNAL_EDGES)
+                    .unwrap()
             };
             shapes.push(decomposed_shape);
 

--- a/examples3d/trimesh3.rs
+++ b/examples3d/trimesh3.rs
@@ -42,7 +42,8 @@ pub fn init_world(testbed: &mut Testbed) {
         vertices,
         indices,
         TriMeshFlags::MERGE_DUPLICATE_VERTICES,
-    );
+    )
+    .unwrap();
     colliders.insert_with_parent(collider, handle, &mut bodies);
 
     /*

--- a/src/counters/mod.rs
+++ b/src/counters/mod.rs
@@ -1,5 +1,6 @@
 //! Counters for benchmarking various parts of the physics engine.
 
+use core::time::Duration;
 use std::fmt::{Display, Formatter, Result};
 
 pub use self::ccd_counters::CCDCounters;
@@ -76,9 +77,14 @@ impl Counters {
         }
     }
 
-    /// Total time spent for one  of the physics engine.
-    pub fn step_time(&self) -> f64 {
+    /// Total time spent for one of the physics engine.
+    pub fn step_time(&self) -> Duration {
         self.step_time.time()
+    }
+
+    /// Total time spent for one of the physics engine, in milliseconds.
+    pub fn step_time_ms(&self) -> f64 {
+        self.step_time.time_ms()
     }
 
     /// Notify that the custom operation has started.
@@ -96,8 +102,13 @@ impl Counters {
     }
 
     /// Total time of a custom event.
-    pub fn custom_time(&self) -> f64 {
+    pub fn custom_time(&self) -> Duration {
         self.custom.time()
+    }
+
+    /// Total time of a custom event, in milliseconds.
+    pub fn custom_time_ms(&self) -> f64 {
+        self.custom.time_ms()
     }
 
     /// Set the number of constraints generated.
@@ -129,7 +140,7 @@ impl Counters {
 }
 
 macro_rules! measure_method {
-    ($started:ident, $stopped:ident, $time:ident, $info:ident. $timer:ident) => {
+    ($started:ident, $stopped:ident, $time_ms:ident, $info:ident. $timer:ident) => {
         impl Counters {
             /// Start this timer.
             pub fn $started(&mut self) {
@@ -145,10 +156,10 @@ macro_rules! measure_method {
                 }
             }
 
-            /// Gets the time elapsed for this timer.
-            pub fn $time(&self) -> f64 {
+            /// Gets the time elapsed for this timer, in milliseconds.
+            pub fn $time_ms(&self) -> f64 {
                 if self.enabled {
-                    self.$info.$timer.time()
+                    self.$info.$timer.time_ms()
                 } else {
                     0.0
                 }
@@ -160,63 +171,63 @@ macro_rules! measure_method {
 measure_method!(
     update_started,
     update_completed,
-    update_time,
+    update_time_ms,
     stages.update_time
 );
 measure_method!(
     collision_detection_started,
     collision_detection_completed,
-    collision_detection_time,
+    collision_detection_time_ms,
     stages.collision_detection_time
 );
 measure_method!(
     island_construction_started,
     island_construction_completed,
-    island_construction_time,
+    island_construction_time_ms,
     stages.island_construction_time
 );
 measure_method!(
     solver_started,
     solver_completed,
-    solver_time,
+    solver_time_ms,
     stages.solver_time
 );
-measure_method!(ccd_started, ccd_completed, ccd_time, stages.ccd_time);
+measure_method!(ccd_started, ccd_completed, ccd_time_ms, stages.ccd_time);
 measure_method!(
     query_pipeline_update_started,
     query_pipeline_update_completed,
-    query_pipeline_update_time,
+    query_pipeline_update_time_ms,
     stages.query_pipeline_time
 );
 
 measure_method!(
     assembly_started,
     assembly_completed,
-    assembly_time,
+    assembly_time_ms,
     solver.velocity_assembly_time
 );
 measure_method!(
     velocity_resolution_started,
     velocity_resolution_completed,
-    velocity_resolution_time,
+    velocity_resolution_time_ms,
     solver.velocity_resolution_time
 );
 measure_method!(
     velocity_update_started,
     velocity_update_completed,
-    velocity_update_time,
+    velocity_update_time_ms,
     solver.velocity_update_time
 );
 measure_method!(
     broad_phase_started,
     broad_phase_completed,
-    broad_phase_time,
+    broad_phase_time_ms,
     cd.broad_phase_time
 );
 measure_method!(
     narrow_phase_started,
     narrow_phase_completed,
-    narrow_phase_time,
+    narrow_phase_time_ms,
     cd.narrow_phase_time
 );
 

--- a/src/counters/timer.rs
+++ b/src/counters/timer.rs
@@ -1,33 +1,36 @@
-use std::fmt::{Display, Error, Formatter};
+use std::{
+    fmt::{Display, Error, Formatter},
+    time::Duration,
+};
 
 /// A timer.
 #[derive(Copy, Clone, Debug, Default)]
 pub struct Timer {
-    time: f64,
+    time: Duration,
     #[allow(dead_code)] // The field isn’t used if the `profiler` feature isn’t enabled.
-    start: Option<f64>,
+    start: Option<std::time::Instant>,
 }
 
 impl Timer {
     /// Creates a new timer initialized to zero and not started.
     pub fn new() -> Self {
         Timer {
-            time: 0.0,
+            time: Duration::from_secs(0),
             start: None,
         }
     }
 
     /// Resets the timer to 0.
     pub fn reset(&mut self) {
-        self.time = 0.0
+        self.time = Duration::from_secs(0)
     }
 
     /// Start the timer.
     pub fn start(&mut self) {
         #[cfg(feature = "profiler")]
         {
-            self.time = 0.0;
-            self.start = Some(instant::now());
+            self.time = Duration::from_secs(0);
+            self.start = Some(web_time::Instant::now());
         }
     }
 
@@ -36,7 +39,7 @@ impl Timer {
         #[cfg(feature = "profiler")]
         {
             if let Some(start) = self.start {
-                self.time += instant::now() - start;
+                self.time += web_time::Instant::now().duration_since(start);
             }
             self.start = None;
         }
@@ -46,18 +49,23 @@ impl Timer {
     pub fn resume(&mut self) {
         #[cfg(feature = "profiler")]
         {
-            self.start = Some(instant::now());
+            self.start = Some(web_time::Instant::now());
         }
     }
 
     /// The measured time between the last `.start()` and `.pause()` calls.
-    pub fn time(&self) -> f64 {
+    pub fn time(&self) -> Duration {
         self.time
+    }
+
+    /// The measured time in milliseconds between the last `.start()` and `.pause()` calls.
+    pub fn time_ms(&self) -> f64 {
+        self.time.as_secs_f64() * 1000.0
     }
 }
 
 impl Display for Timer {
     fn fmt(&self, f: &mut Formatter) -> Result<(), Error> {
-        write!(f, "{}s", self.time)
+        write!(f, "{}ms", self.time_ms())
     }
 }

--- a/src/data/arena.rs
+++ b/src/data/arena.rs
@@ -965,7 +965,7 @@ impl<'a, T> Iterator for Iter<'a, T> {
     }
 }
 
-impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
+impl<T> DoubleEndedIterator for Iter<'_, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
         loop {
             match self.inner.next_back() {
@@ -993,13 +993,13 @@ impl<'a, T> DoubleEndedIterator for Iter<'a, T> {
     }
 }
 
-impl<'a, T> ExactSizeIterator for Iter<'a, T> {
+impl<T> ExactSizeIterator for Iter<'_, T> {
     fn len(&self) -> usize {
         self.len
     }
 }
 
-impl<'a, T> FusedIterator for Iter<'a, T> {}
+impl<T> FusedIterator for Iter<'_, T> {}
 
 impl<'a, T> IntoIterator for &'a mut Arena<T> {
     type Item = (Index, &'a mut T);
@@ -1069,7 +1069,7 @@ impl<'a, T> Iterator for IterMut<'a, T> {
     }
 }
 
-impl<'a, T> DoubleEndedIterator for IterMut<'a, T> {
+impl<T> DoubleEndedIterator for IterMut<'_, T> {
     fn next_back(&mut self) -> Option<Self::Item> {
         loop {
             match self.inner.next_back() {
@@ -1097,13 +1097,13 @@ impl<'a, T> DoubleEndedIterator for IterMut<'a, T> {
     }
 }
 
-impl<'a, T> ExactSizeIterator for IterMut<'a, T> {
+impl<T> ExactSizeIterator for IterMut<'_, T> {
     fn len(&self) -> usize {
         self.len
     }
 }
 
-impl<'a, T> FusedIterator for IterMut<'a, T> {}
+impl<T> FusedIterator for IterMut<'_, T> {}
 
 /// An iterator that removes elements from the arena.
 ///
@@ -1135,7 +1135,7 @@ pub struct Drain<'a, T: 'a> {
     inner: iter::Enumerate<vec::Drain<'a, Entry<T>>>,
 }
 
-impl<'a, T> Iterator for Drain<'a, T> {
+impl<T> Iterator for Drain<'_, T> {
     type Item = (Index, T);
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/data/graph.rs
+++ b/src/data/graph.rs
@@ -531,7 +531,7 @@ fn edges_walker_mut<E>(
     EdgesWalkerMut { edges, next, dir }
 }
 
-impl<'a, E> EdgesWalkerMut<'a, E> {
+impl<E> EdgesWalkerMut<'_, E> {
     fn next_edge(&mut self) -> Option<&mut Edge<E>> {
         self.next().map(|t| t.1)
     }
@@ -630,7 +630,7 @@ impl<'a, E> Iterator for Edges<'a, E> {
 //     x
 // }
 
-impl<'a, E> Clone for Edges<'a, E> {
+impl<E> Clone for Edges<'_, E> {
     fn clone(&self) -> Self {
         Edges {
             skip_start: self.skip_start,
@@ -699,15 +699,15 @@ impl<'a, E: 'a> EdgeReference<'a, E> {
     }
 }
 
-impl<'a, E> Clone for EdgeReference<'a, E> {
+impl<E> Clone for EdgeReference<'_, E> {
     fn clone(&self) -> Self {
         *self
     }
 }
 
-impl<'a, E> Copy for EdgeReference<'a, E> {}
+impl<E> Copy for EdgeReference<'_, E> {}
 
-impl<'a, E> PartialEq for EdgeReference<'a, E>
+impl<E> PartialEq for EdgeReference<'_, E>
 where
     E: PartialEq,
 {

--- a/src/dynamics/island_manager.rs
+++ b/src/dynamics/island_manager.rs
@@ -165,7 +165,7 @@ impl IslandManager {
 
         // Update the energy of every rigid body and
         // keep only those that may not sleep.
-        //        let t = instant::now();
+        //        let t = Instant::now();
         self.active_set_timestamp += 1;
         self.stack.clear();
         self.can_sleep.clear();
@@ -235,9 +235,9 @@ impl IslandManager {
             push_contacting_bodies(&rb.colliders, colliders, narrow_phase, &mut self.stack);
         }
 
-        //        println!("Selection: {}", instant::now() - t);
+        //        println!("Selection: {}", Instant::now() - t);
 
-        //        let t = instant::now();
+        //        let t = Instant::now();
         // Propagation of awake state and awake island computation through the
         // traversal of the interaction graph.
         self.active_islands_additional_solver_iterations.clear();
@@ -310,7 +310,7 @@ impl IslandManager {
         self.active_islands.push(self.active_dynamic_set.len());
         //        println!(
         //            "Extraction: {}, num islands: {}",
-        //            instant::now() - t,
+        //            Instant::now() - t,
         //            self.active_islands.len() - 1
         //        );
 

--- a/src/dynamics/solver/contact_constraint/two_body_constraint.rs
+++ b/src/dynamics/solver/contact_constraint/two_body_constraint.rs
@@ -11,7 +11,7 @@ use na::{DVector, Matrix2};
 
 use super::{TwoBodyConstraintElement, TwoBodyConstraintNormalPart};
 
-impl<'a> AnyConstraintMut<'a, ContactConstraintTypes> {
+impl AnyConstraintMut<'_, ContactConstraintTypes> {
     pub fn remove_bias(&mut self) {
         match self {
             Self::OneBody(c) => c.remove_cfm_and_bias_from_rhs(),

--- a/src/dynamics/solver/interaction_groups.rs
+++ b/src/dynamics/solver/interaction_groups.rs
@@ -18,7 +18,7 @@ pub(crate) trait PairInteraction {
 use crate::dynamics::RigidBodyType;
 
 #[cfg(feature = "parallel")]
-impl<'a> PairInteraction for &'a mut ContactManifold {
+impl PairInteraction for &mut ContactManifold {
     fn body_pair(&self) -> (Option<RigidBodyHandle>, Option<RigidBodyHandle>) {
         (self.data.rigid_body1, self.data.rigid_body2)
     }

--- a/src/dynamics/solver/joint_constraint/any_joint_constraint.rs
+++ b/src/dynamics/solver/joint_constraint/any_joint_constraint.rs
@@ -27,7 +27,7 @@ use crate::dynamics::solver::joint_constraint::joint_constraint_builder::{
 
 pub struct JointConstraintTypes;
 
-impl<'a> AnyConstraintMut<'a, JointConstraintTypes> {
+impl AnyConstraintMut<'_, JointConstraintTypes> {
     pub fn remove_bias(&mut self) {
         match self {
             Self::OneBody(c) => c.remove_bias_from_rhs(),

--- a/src/geometry/collider.rs
+++ b/src/geometry/collider.rs
@@ -10,7 +10,7 @@ use crate::pipeline::{ActiveEvents, ActiveHooks};
 use crate::prelude::ColliderEnabled;
 use na::Unit;
 use parry::bounding_volume::{Aabb, BoundingVolume};
-use parry::shape::{Shape, TriMeshFlags};
+use parry::shape::{Shape, TriMeshBuilderError, TriMeshFlags};
 
 #[cfg(feature = "dim3")]
 use crate::geometry::HeightFieldFlags;
@@ -685,8 +685,11 @@ impl ColliderBuilder {
     }
 
     /// Initializes a collider builder with a triangle mesh shape defined by its vertex and index buffers.
-    pub fn trimesh(vertices: Vec<Point<Real>>, indices: Vec<[u32; 3]>) -> Self {
-        Self::new(SharedShape::trimesh(vertices, indices))
+    pub fn trimesh(
+        vertices: Vec<Point<Real>>,
+        indices: Vec<[u32; 3]>,
+    ) -> Result<Self, TriMeshBuilderError> {
+        Ok(Self::new(SharedShape::trimesh(vertices, indices)?))
     }
 
     /// Initializes a collider builder with a triangle mesh shape defined by its vertex and index buffers and
@@ -695,8 +698,10 @@ impl ColliderBuilder {
         vertices: Vec<Point<Real>>,
         indices: Vec<[u32; 3]>,
         flags: TriMeshFlags,
-    ) -> Self {
-        Self::new(SharedShape::trimesh_with_flags(vertices, indices, flags))
+    ) -> Result<Self, TriMeshBuilderError> {
+        Ok(Self::new(SharedShape::trimesh_with_flags(
+            vertices, indices, flags,
+        )?))
     }
 
     /// Initializes a collider builder with a shape converted from the given triangle mesh index

--- a/src/geometry/mesh_converter.rs
+++ b/src/geometry/mesh_converter.rs
@@ -1,6 +1,6 @@
 use parry::bounding_volume;
 use parry::math::{Isometry, Point, Real};
-use parry::shape::{Cuboid, SharedShape, TriMeshFlags};
+use parry::shape::{Cuboid, SharedShape, TriMeshBuilderError, TriMeshFlags};
 
 #[cfg(feature = "dim3")]
 use parry::transformation::vhacd::VHACDParameters;
@@ -17,6 +17,9 @@ pub enum MeshConverterError {
     /// The convex hull calculation carried out by the [`MeshConverter::ConvexHull`] failed.
     #[error("convex-hull computation failed")]
     ConvexHullFailed,
+    /// The TriMesh building failed.
+    #[error("TriMesh building failed")]
+    TriMeshBuilderError(TriMeshBuilderError),
 }
 
 /// Determines how meshes (generally when loaded from a file) are converted into Rapier colliders.
@@ -61,9 +64,11 @@ impl MeshConverter {
     ) -> Result<(SharedShape, Isometry<Real>), MeshConverterError> {
         let mut transform = Isometry::identity();
         let shape = match self {
-            MeshConverter::TriMesh => SharedShape::trimesh(vertices, indices),
+            MeshConverter::TriMesh => SharedShape::trimesh(vertices, indices)
+                .map_err(MeshConverterError::TriMeshBuilderError)?,
             MeshConverter::TriMeshWithFlags(flags) => {
                 SharedShape::trimesh_with_flags(vertices, indices, *flags)
+                    .map_err(MeshConverterError::TriMeshBuilderError)?
             }
             MeshConverter::Obb => {
                 let (pose, cuboid) = parry::utils::obb(&vertices);

--- a/src/pipeline/physics_hooks.rs
+++ b/src/pipeline/physics_hooks.rs
@@ -45,7 +45,7 @@ pub struct ContactModificationContext<'a> {
     pub user_data: &'a mut u32,
 }
 
-impl<'a> ContactModificationContext<'a> {
+impl ContactModificationContext<'_> {
     /// Helper function to update `self` to emulate a oneway-platform.
     ///
     /// The "oneway" behavior will only allow contacts between two colliders

--- a/src/pipeline/query_pipeline/generators.rs
+++ b/src/pipeline/query_pipeline/generators.rs
@@ -30,7 +30,7 @@ pub struct SweptAabbWithPredictedPosition<'a> {
     /// You probably want to set it to [`IntegrationParameters::dt`].
     pub dt: Real,
 }
-impl<'a> QbvhDataGenerator<ColliderHandle> for SweptAabbWithPredictedPosition<'a> {
+impl QbvhDataGenerator<ColliderHandle> for SweptAabbWithPredictedPosition<'_> {
     fn size_hint(&self) -> usize {
         self.colliders.len()
     }
@@ -68,7 +68,7 @@ pub struct SweptAabbWithNextPosition<'a> {
     pub colliders: &'a ColliderSet,
 }
 
-impl<'a> QbvhDataGenerator<ColliderHandle> for SweptAabbWithNextPosition<'a> {
+impl QbvhDataGenerator<ColliderHandle> for SweptAabbWithNextPosition<'_> {
     fn size_hint(&self) -> usize {
         self.colliders.len()
     }
@@ -96,7 +96,7 @@ pub struct CurrentAabb<'a> {
     pub colliders: &'a ColliderSet,
 }
 
-impl<'a> QbvhDataGenerator<ColliderHandle> for CurrentAabb<'a> {
+impl QbvhDataGenerator<ColliderHandle> for CurrentAabb<'_> {
     fn size_hint(&self) -> usize {
         self.colliders.len()
     }

--- a/src/pipeline/query_pipeline/mod.rs
+++ b/src/pipeline/query_pipeline/mod.rs
@@ -488,9 +488,9 @@ impl QueryPipeline {
             &pipeline_shape,
             shape,
         );
-        self.qbvh
-            .traverse_best_first(&mut visitor)
-            .map(|h| (h.1 .0))
+
+        self.qbvh.traverse_depth_first(&mut visitor);
+        visitor.found_intersection
     }
 
     /// Find the projection of a point on the closest collider.

--- a/src/pipeline/query_pipeline/mod.rs
+++ b/src/pipeline/query_pipeline/mod.rs
@@ -480,17 +480,14 @@ impl QueryPipeline {
         filter: QueryFilter,
     ) -> Option<ColliderHandle> {
         let pipeline_shape = self.as_composite_shape(bodies, colliders, filter);
-        #[allow(deprecated)]
         // TODO: replace this with IntersectionCompositeShapeShapeVisitor when it
         //        can return the shape part id.
-        let mut visitor =
-            parry::query::details::IntersectionCompositeShapeShapeBestFirstVisitor::new(
-                &*self.query_dispatcher,
-                shape_pos,
-                &pipeline_shape,
-                shape,
-            );
-
+        let mut visitor = parry::query::details::IntersectionCompositeShapeShapeVisitor::new(
+            &*self.query_dispatcher,
+            shape_pos,
+            &pipeline_shape,
+            shape,
+        );
         self.qbvh
             .traverse_best_first(&mut visitor)
             .map(|h| (h.1 .0))

--- a/src/pipeline/query_pipeline/mod.rs
+++ b/src/pipeline/query_pipeline/mod.rs
@@ -119,7 +119,7 @@ pub struct QueryFilter<'a> {
     pub predicate: Option<&'a dyn Fn(ColliderHandle, &Collider) -> bool>,
 }
 
-impl<'a> QueryFilter<'a> {
+impl QueryFilter<'_> {
     /// Applies the filters described by `self` to a collider to determine if it has to be
     /// included in a scene query (`true`) or not (`false`).
     #[inline]
@@ -136,7 +136,7 @@ impl<'a> QueryFilter<'a> {
     }
 }
 
-impl<'a> From<QueryFilterFlags> for QueryFilter<'a> {
+impl From<QueryFilterFlags> for QueryFilter<'_> {
     fn from(flags: QueryFilterFlags) -> Self {
         Self {
             flags,
@@ -145,7 +145,7 @@ impl<'a> From<QueryFilterFlags> for QueryFilter<'a> {
     }
 }
 
-impl<'a> From<InteractionGroups> for QueryFilter<'a> {
+impl From<InteractionGroups> for QueryFilter<'_> {
     fn from(groups: InteractionGroups) -> Self {
         Self {
             groups: Some(groups),
@@ -229,7 +229,7 @@ impl<'a> QueryFilter<'a> {
     }
 }
 
-impl<'a> TypedSimdCompositeShape for QueryPipelineAsCompositeShape<'a> {
+impl TypedSimdCompositeShape for QueryPipelineAsCompositeShape<'_> {
     type PartShape = dyn Shape;
     type PartNormalConstraints = dyn NormalConstraints;
     type PartId = ColliderHandle;

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -249,7 +249,7 @@ impl TestbedApp {
     }
 
     pub fn run_with_init(mut self, mut init: impl FnMut(&mut App)) {
-        #[cfg(feature = "profiling")]
+        #[cfg(feature = "profiler_ui")]
         puffin_egui::puffin::set_scopes_on(true);
 
         let mut args = env::args();

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -469,7 +469,7 @@ impl TestbedApp {
     }
 }
 
-impl<'a, 'b, 'c, 'd, 'e, 'f> TestbedGraphics<'a, 'b, 'c, 'd, 'e, 'f> {
+impl TestbedGraphics<'_, '_, '_, '_, '_, '_> {
     pub fn set_body_color(&mut self, body: RigidBodyHandle, color: [f32; 3]) {
         self.graphics.set_body_color(self.materials, body, color);
     }
@@ -526,7 +526,7 @@ impl<'a, 'b, 'c, 'd, 'e, 'f> TestbedGraphics<'a, 'b, 'c, 'd, 'e, 'f> {
     }
 }
 
-impl<'a, 'b, 'c, 'd, 'e, 'f> Testbed<'a, 'b, 'c, 'd, 'e, 'f> {
+impl Testbed<'_, '_, '_, '_, '_, '_> {
     pub fn set_number_of_steps_per_frame(&mut self, nsteps: usize) {
         self.state.nsteps = nsteps
     }

--- a/src_testbed/testbed.rs
+++ b/src_testbed/testbed.rs
@@ -393,7 +393,8 @@ impl TestbedApp {
 
                         // Skip the first update.
                         if k > 0 {
-                            timings.push(self.harness.physics.pipeline.counters.step_time.time());
+                            timings
+                                .push(self.harness.physics.pipeline.counters.step_time.time_ms());
                         }
                     }
                     results.push(timings);

--- a/src_testbed/ui.rs
+++ b/src_testbed/ui.rs
@@ -22,7 +22,7 @@ pub fn update_ui(
     harness: &mut Harness,
     debug_render: &mut DebugRenderPipelineResource,
 ) {
-    #[cfg(feature = "profiling")]
+    #[cfg(feature = "profiler_ui")]
     {
         let window = egui::Window::new("Profiling");
         let window = window.default_open(false);

--- a/src_testbed/ui.rs
+++ b/src_testbed/ui.rs
@@ -14,6 +14,7 @@ use crate::PhysicsState;
 use bevy_egui::egui::{Slider, Ui};
 use bevy_egui::{egui, EguiContexts};
 use rapier::dynamics::IntegrationParameters;
+use web_time::Instant;
 
 pub fn update_ui(
     ui_context: &mut EguiContexts,
@@ -359,94 +360,100 @@ fn scene_infos_ui(ui: &mut Ui, physics: &PhysicsState) {
 fn profiling_ui(ui: &mut Ui, counters: &Counters) {
     egui::CollapsingHeader::new(format!(
         "Total: {:.2}ms - {} fps",
-        counters.step_time(),
-        (1000.0 / counters.step_time()).round()
+        counters.step_time_ms(),
+        (1000.0 / counters.step_time_ms()).round()
     ))
     .id_source("total")
     .show(ui, |ui| {
         egui::CollapsingHeader::new(format!(
             "Collision detection: {:.2}ms",
-            counters.collision_detection_time()
+            counters.collision_detection_time_ms()
         ))
         .id_source("collision detection")
         .show(ui, |ui| {
-            ui.label(format!("Broad-phase: {:.2}ms", counters.broad_phase_time()));
+            ui.label(format!(
+                "Broad-phase: {:.2}ms",
+                counters.broad_phase_time_ms()
+            ));
             ui.label(format!(
                 "Narrow-phase: {:.2}ms",
-                counters.narrow_phase_time()
+                counters.narrow_phase_time_ms()
             ));
         });
-        egui::CollapsingHeader::new(format!("Solver: {:.2}ms", counters.solver_time()))
+        egui::CollapsingHeader::new(format!("Solver: {:.2}ms", counters.solver_time_ms()))
             .id_source("solver")
             .show(ui, |ui| {
                 ui.label(format!(
                     "Velocity assembly: {:.2}ms",
-                    counters.solver.velocity_assembly_time.time()
+                    counters.solver.velocity_assembly_time.time_ms()
                 ));
                 ui.label(format!(
                     "Velocity resolution: {:.2}ms",
-                    counters.velocity_resolution_time()
+                    counters.velocity_resolution_time_ms()
                 ));
                 ui.label(format!(
                     "Velocity integration: {:.2}ms",
-                    counters.solver.velocity_update_time.time()
+                    counters.solver.velocity_update_time.time_ms()
                 ));
                 ui.label(format!(
                     "Writeback: {:.2}ms",
-                    counters.solver.velocity_writeback_time.time()
+                    counters.solver.velocity_writeback_time.time_ms()
                 ));
             });
-        egui::CollapsingHeader::new(format!("CCD: {:.2}ms", counters.ccd_time()))
+        egui::CollapsingHeader::new(format!("CCD: {:.2}ms", counters.ccd_time_ms()))
             .id_source("ccd")
             .show(ui, |ui| {
                 ui.label(format!("# of substeps: {}", counters.ccd.num_substeps));
                 ui.label(format!(
                     "TOI computation: {:.2}ms",
-                    counters.ccd.toi_computation_time.time(),
+                    counters.ccd.toi_computation_time.time_ms(),
                 ));
                 ui.label(format!(
                     "Broad-phase: {:.2}ms",
-                    counters.ccd.broad_phase_time.time()
+                    counters.ccd.broad_phase_time.time_ms()
                 ));
                 ui.label(format!(
                     "Narrow-phase: {:.2}ms",
-                    counters.ccd.narrow_phase_time.time(),
+                    counters.ccd.narrow_phase_time.time_ms(),
                 ));
-                ui.label(format!("Solver: {:.2}ms", counters.ccd.solver_time.time()));
+                ui.label(format!(
+                    "Solver: {:.2}ms",
+                    counters.ccd.solver_time.time_ms()
+                ));
             });
         ui.label(format!(
             "Island computation: {:.2}ms",
-            counters.island_construction_time()
+            counters.island_construction_time_ms()
         ));
         ui.label(format!(
             "Query pipeline: {:.2}ms",
-            counters.query_pipeline_update_time()
+            counters.query_pipeline_update_time_ms()
         ));
         ui.label(format!(
             "User changes: {:.2}ms",
-            counters.stages.user_changes.time()
+            counters.stages.user_changes.time_ms()
         ));
     });
 }
 
 fn serialization_string(timestep_id: usize, physics: &PhysicsState) -> String {
-    let t = instant::now();
-    // let t = instant::now();
+    let t = Instant::now();
+    // let t = Instant::now();
     let bf = bincode::serialize(&physics.broad_phase).unwrap();
-    // println!("bf: {}", instant::now() - t);
-    // let t = instant::now();
+    // println!("bf: {}", Instant::now() - t);
+    // let t = Instant::now();
     let nf = bincode::serialize(&physics.narrow_phase).unwrap();
-    // println!("nf: {}", instant::now() - t);
-    // let t = instant::now();
+    // println!("nf: {}", Instant::now() - t);
+    // let t = Instant::now();
     let bs = bincode::serialize(&physics.bodies).unwrap();
-    // println!("bs: {}", instant::now() - t);
-    // let t = instant::now();
+    // println!("bs: {}", Instant::now() - t);
+    // let t = Instant::now();
     let cs = bincode::serialize(&physics.colliders).unwrap();
-    // println!("cs: {}", instant::now() - t);
-    // let t = instant::now();
+    // println!("cs: {}", Instant::now() - t);
+    // let t = Instant::now();
     let js = bincode::serialize(&physics.impulse_joints).unwrap();
-    // println!("js: {}", instant::now() - t);
-    let serialization_time = instant::now() - t;
+    // println!("js: {}", Instant::now() - t);
+    let serialization_time = Instant::now() - t;
     let hash_bf = md5::compute(&bf);
     let hash_nf = md5::compute(&nf);
     let hash_bodies = md5::compute(&bs);
@@ -460,7 +467,7 @@ Hashes at frame: {}
 |_ &RigidBodySet [{:.1}KB]: {}
 |_ Colliders [{:.1}KB]: {}
 |_ Joints [{:.1}KB]: {}"#,
-        serialization_time,
+        serialization_time.as_secs_f64() * 1000.0,
         timestep_id,
         bf.len() as f32 / 1000.0,
         format!("{:?}", hash_bf).split_at(10).0,


### PR DESCRIPTION
- builds on top of https://github.com/dimforge/rapier/pull/763 to use `traverse_depth_first` within `intersection_with_shape`.
- This is not testable as-is because it needs a small update from parry to support `visitor.found_intersection`, which is a controversial change.

See following trace with example 2d 100 x 100 balls:

- :yellow_square: this trace is master (traverse_best_first)
- :red_square: external trace is this PR (traverse_depth_first)

![image](https://github.com/user-attachments/assets/4be1529b-4152-4d48-851d-cd9b00628150)